### PR TITLE
Update Forest Tiles with New Background Image

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -61,7 +61,13 @@ body {
 
 .tile.water{ background: var(--blue); }
 .tile.land{ background: var(--green); }
-.tile.forest{ background: #065f46; }
+.tile.forest{
+  background-color: var(--green); /* match land color under sprite */
+  background-image: url('./images/forest.png');
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+} /* forest texture */
 .tile.mountain{
   background-color: var(--green); /* match land color under sprite */
   background-image: url('./images/mountain.png');


### PR DESCRIPTION
This PR replaces the existing forest tile background color with a new background that uses 'forest.png'. It modifies the CSS class for the forest tiles to incorporate a green background color that matches the land tiles, and adds the forest image with no-repeat, centered positioning, and containment sizing for better visual integration.

---

> This pull request was co-created with Cosine Genie

Original Task: [rpg-engine/ord9f5u84n7s](https://cosine.sh/cosine/rpg-engine/task/ord9f5u84n7s)
Author: Curtis Huang
