### PR TITLE
Replace player red circle with knight.png

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -81,8 +81,10 @@ body {
 .tile .player{
   width: 100%;
   height: 100%;
-  background: var(--red);
-  border-radius: 50%;
+  background-image: url('./images/knight.png');
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
 }
 
 /* CUTSCENE DIALOGUE */


### PR DESCRIPTION
This pull request replaces the player representation in the game from a red circle to a knight image. The modification in `assets/style.css` updates the CSS class for the player by changing its background to the knight image, which is styled to fit appropriately within the designated area. This change enhances the visual representation of the player character.

---

> This pull request was co-created with Cosine Genie

Original Task: [rpg-engine/dsloht82rnwc](https://cosine.sh/cosine/rpg-engine/task/dsloht82rnwc)
Author: Curtis Huang
